### PR TITLE
Add no-GUI build option to eliminate CGO dependency on Linux servers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 </div>
 
+## no-gui 构建方法
+
+```bash
+go build -tags="no_gui"
+```
+
 ## 原理
 
 此项目是通过部署此项目本身的服务器来获取 `github.com` 的 `hosts`，而不是通过第三方ip地址接口来进行获取，例如 `ipaddress.com` 等。

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,6 +13,12 @@
 
 </div>
 
+## no-gui build
+
+```bash
+go build -tags="no_gui"
+```
+
 ## Principle
 
 This project obtains the `hosts` of `github.com` by deploying the server of the project itself, rather than through a third-party IP address interface, such as `ipaddress.com`, etc.

--- a/gui.go
+++ b/gui.go
@@ -1,8 +1,20 @@
+//go:build !no_gui
+// +build !no_gui
+
 package main
 
 import (
 	"encoding/json"
 	"fmt"
+	"image/color"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
@@ -13,14 +25,6 @@ import (
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
-	"image/color"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var mainWindow fyne.Window

--- a/gui_theme.go
+++ b/gui_theme.go
@@ -1,9 +1,13 @@
+//go:build !no_gui
+// +build !no_gui
+
 package main
 
 import (
+	"image/color"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/theme"
-	"image/color"
 )
 
 type fghGuiTheme struct {

--- a/no_gui.go
+++ b/no_gui.go
@@ -1,0 +1,25 @@
+//go:build no_gui
+// +build no_gui
+
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+var _fileLog *FetchLog
+
+func bootGui() {
+	fmt.Println("GUI is not supported in this build")
+	fmt.Println("Please use the command line interface")
+	fmt.Println("For example: sudo ./fetch-github-hosts -m client ")
+}
+
+func getTicker(interval int) *time.Ticker {
+	d := time.Minute
+	if IsDebug() {
+		d = time.Second
+	}
+	return time.NewTicker(d * time.Duration(interval))
+}


### PR DESCRIPTION
Introduced a no-gui build flag to provide a lightweight build option for Linux servers without GUI-related features.
Removes the need for CGO by excluding GUI-related dependencies in no-gui builds.

Benefits:
- Simplifies deployment on Linux servers.
- Improves portability by avoiding CGO.
- Reduces build size and potential runtime overhead.

Usage:

`go build -tags no-gui`

No functional changes for default builds with GUI enabled.